### PR TITLE
feat: switch to smol-toml for toml parsing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -48,30 +48,32 @@ THE SOFTWARE.
 
 ---
 
-toml: https://github.com/BinaryMuse/toml-node/blob/master/LICENSE
+smol-toml: https://github.com/squirrelchat/smol-toml/blob/mistress/LICENSE
 
-Copyright (c) 2012 Michelle Tilley
+Copyright (c) Squirrel Chat et al., All rights reserved.
 
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Config parsers for:
 
 ✅ [YAML](https://yaml.org/) (with [`js-yaml`](https://github.com/nodeca/js-yaml))
 
-✅ [TOML](https://toml.io/) (with [`toml`](https://github.com/BinaryMuse/toml-node)
+✅ [TOML](https://toml.io/) (with [`smol-toml`](https://github.com/squirrelchat/smol-toml))
 
 ✅ [JSONC](https://github.com/microsoft/node-jsonc-parser) (with [`jsonc-parser`](https://github.com/microsoft/node-jsonc-parser))
 
@@ -102,7 +102,6 @@ Converts a [YAML](https://yaml.org/) string into an object.
 ### `stringifyYAML(value, options?)`
 
 Converts a JavaScript value to a [YAML](https://yaml.org/) string.
-
 
 <!-- /automd -->
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jsonc-parser": "^3.2.1",
     "mitata": "^0.1.11",
     "prettier": "^3.2.5",
+    "smol-toml": "^1.1.4",
     "toml": "^3.0.0",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ devDependencies:
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
+  smol-toml:
+    specifier: ^1.1.4
+    version: 1.1.4
   toml:
     specifier: ^3.0.0
     version: 3.0.0
@@ -4477,6 +4480,11 @@ packages:
   /slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
+    dev: true
+
+  /smol-toml@1.1.4:
+    resolution: {integrity: sha512-Y0OT8HezWsTNeEOSVxDnKOW/AyNXHQ4BwJNbAXlLTF5wWsBvrcHhIkE5Rf8kQMLmgf7nDX3PVOlgC6/Aiggu3Q==}
+    engines: {node: '>= 18', pnpm: '>= 8'}
     dev: true
 
   /source-map-js@1.0.2:

--- a/src/toml.ts
+++ b/src/toml.ts
@@ -1,6 +1,6 @@
-import { parse } from "toml";
+import { parse } from "smol-toml";
 
-// Source: https://github.com/BinaryMuse/toml-node
+// Source: https://github.com/squirrelchat/smol-toml
 
 /**
  * Converts a [TOML](https://toml.io/) string into an object.

--- a/test/bench.mjs
+++ b/test/bench.mjs
@@ -2,6 +2,7 @@ import { bench, baseline, run, group } from "mitata";
 
 import nodeToml from "toml";
 import * as jsToml from "js-toml";
+import * as smolToml from "smol-toml";
 import jsYaml from "js-yaml";
 import yaml from "yaml";
 import * as json5 from "json5";
@@ -46,6 +47,9 @@ defineBench("toml", {
   },
   "sunnyadn/js-toml": () => {
     jsToml.load(fixtures.toml);
+  },
+  "squirrelchat/smol-toml": () => {
+    smolToml.parse(fixtures.toml);
   },
 });
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The TOML parser currently in use, https://github.com/BinaryMuse/toml-node, only supports the 0.4.0 spec, and therefore has many open issues regarding unsupported features. On the other hand, https://github.com/squirrelchat/smol-toml supports the latest 1.0.0 spec and has zero spec-related issues open. In addition, I believe the performance is significantly better with `smol-toml`:

```
• toml
-------------------------------------------------------------------
confbox                       2'060 ns/iter   (1'729 ns … 3'123 ns)
BinaryMuse/toml-node         18'563 ns/iter    (15'625 ns … 340 µs)
sunnyadn/js-toml             18'722 ns/iter    (17'333 ns … 337 µs)
squirrelchat/smol-toml        1'470 ns/iter   (1'409 ns … 1'731 ns)

summary for toml
  confbox
   1.4x slower than squirrelchat/smol-toml
   9.01x faster than BinaryMuse/toml-node
   9.09x faster than sunnyadn/js-toml
```

If I'm reading that correctly, the current parser is 1.4 times slower than `smol-toml`!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
