### PR TITLE
feat: json utilities with format and whitespace preservation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -102,3 +102,17 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+detect-indent: https://github.com/sindresorhus/detect-indent/blob/main/license
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Config parsers for:
 
 ✅ [JSON5](https://json5.org/) (with [`json5`](https://github.com/json5/json5))
 
+✅ [JSON](https://www.json.org/json-en.html) (with format and whitespace preservation)
+
 With perfect bundling:
 
 ✨ Types exported out of the box
@@ -28,6 +30,8 @@ With perfect bundling:
 ✨ Consistent and tested API
 
 ✨ Handpicked best libraries (bundle+perf)
+
+✨ Auto-preserves the indentation and whitespace.
 
 > [!NOTE]
 > Use [unjs/c12](https://github.com/unjs/c12) for a full featured configuration loader!
@@ -71,6 +75,8 @@ import {
   stringifyYAML,
   parseTOML,
   stringifyTOML,
+  parseJSON,
+  stringifyJSON,
 } from "confbox";
 ```
 
@@ -84,6 +90,8 @@ const {
   stringifyYAML,
   parseTOML,
   stringifyTOML,
+  parseJSON,
+  stringifyJSON,
 } = require("confbox");
 ```
 
@@ -97,12 +105,20 @@ import {
   stringifyYAML,
   parseTOML,
   stringifyTOML,
+  parseJSON,
+  stringifyJSON,
 } from "https://esm.sh/confbox";
 ```
 
 <!-- /automd -->
 
 <!-- automd:jsdocs src="./src/index" -->
+
+### `parseJSON(text, options?)`
+
+Converts a [JSON](https://www.json.org/json-en.html) string into an object.
+
+Indentation status is auto-detected and preserved when stringifying back using `stringifyJSON`
 
 ### `parseJSON5(text, options?)`
 
@@ -119,6 +135,12 @@ Converts a [TOML](https://toml.io/) string into an object.
 ### `parseYAML(text, options?)`
 
 Converts a [YAML](https://yaml.org/) string into an object.
+
+### `stringifyJSON(value, options?)`
+
+Converts a JavaScript value to a [JSON](https://www.json.org/json-en.html) string.
+
+Indentation status is auto detected and preserved when using value from parseJSON.
 
 ### `stringifyTOML(value)`
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@vitest/coverage-v8": "^1.5.0",
     "automd": "^0.3.7",
     "changelogen": "^0.5.5",
+    "detect-indent": "^7.0.1",
     "eslint": "^9.0.0",
     "eslint-config-unjs": "0.3.0-rc.6",
     "jiti": "^1.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       changelogen:
         specifier: ^0.5.5
         version: 0.5.5
+      detect-indent:
+        specifier: ^7.0.1
+        version: 7.0.1
       eslint:
         specifier: ^9.0.0
         version: 9.0.0
@@ -1176,6 +1179,10 @@ packages:
 
   destr@2.0.3:
     resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
+
+  detect-indent@7.0.1:
+    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
+    engines: {node: '>=12.20'}
 
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
@@ -3643,6 +3650,8 @@ snapshots:
   defu@6.1.4: {}
 
   destr@2.0.3: {}
+
+  detect-indent@7.0.1: {}
 
   detect-libc@1.0.3: {}
 

--- a/src/_format.ts
+++ b/src/_format.ts
@@ -1,0 +1,96 @@
+import detectIndent from "detect-indent";
+
+export interface FormatInfo {
+  sample?: string;
+  whiteSpace?: { start: string; end: string };
+}
+
+export interface FormatOptions {
+  /**
+   * A String or Number object that's used to insert white space into the output JSON string for readability purposes.
+   *
+   * When provided, identation won't be auto detected anymore.
+   */
+  indent?: string | number;
+
+  /**
+   * Set to `false` to skip indentation preservation.
+   */
+  preserveIndentation?: boolean;
+
+  /**
+   * Set to `false` to skip whitespace preservation.
+   */
+  preserveWhitespace?: boolean;
+
+  /**
+   * The number of characters to sample from the start of the text.
+   *
+   * Default: 1024
+   */
+  sampleSize?: number;
+}
+
+const ftmSymbol = Symbol.for("__confbox_fmt__");
+
+const WhitespaceStartRe = /^(\s+)/;
+const WhitespaceEndRe = /(\s+)$/;
+
+export function detectFormat(
+  text: string,
+  opts: FormatOptions = {},
+): FormatInfo {
+  // Keep ref to a sample of the original text only if need to later detect indent to reduce memory usage.
+  const sample =
+    opts.indent === undefined &&
+    opts.preserveIndentation !== false &&
+    text.slice(0, opts?.sampleSize || 1024);
+
+  const whiteSpace =
+    opts.preserveWhitespace === false
+      ? undefined
+      : {
+          start: WhitespaceStartRe.exec(text)?.[0] || "",
+          end: WhitespaceEndRe.exec(text)?.[0] || "",
+        };
+
+  return <FormatInfo>{
+    sample,
+    whiteSpace,
+  };
+}
+
+export function storeFormat(
+  text: string,
+  obj: any,
+  opts?: FormatOptions,
+): void {
+  if (!obj || typeof obj !== "object") {
+    return;
+  }
+
+  Object.defineProperty(obj, ftmSymbol, {
+    enumerable: false,
+    configurable: true,
+    writable: true,
+    value: detectFormat(text, opts),
+  });
+}
+
+export function getFormat(
+  obj: any,
+  opts?: FormatOptions,
+): {
+  indent: string | number | undefined;
+  whitespace: { start: string; end: string };
+} {
+  if (!obj || typeof obj !== "object" || !(ftmSymbol in obj)) {
+    return { indent: opts?.indent, whitespace: { start: "", end: "" } };
+  }
+  const format = obj[ftmSymbol] as FormatInfo;
+  const indent = opts?.indent || detectIndent(format.sample || "").indent;
+  return {
+    indent,
+    whitespace: format.whiteSpace || { start: "", end: "" },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,6 @@ export { parseYAML, stringifyYAML } from "./yaml";
 export type { parseYAMLOptions, stringifyYAMLOptions } from "./yaml";
 
 export { parseTOML, stringifyTOML } from "./toml";
+
+export { parseJSON, stringifyJSON } from "./json";
+export type { JSONParseOptions, JSONStringifyOptions } from "./json";

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,0 +1,45 @@
+import { getFormat, storeFormat, type FormatOptions } from "./_format";
+
+/**
+ * Converts a [JSON](https://www.json.org/json-en.html) string into an object.
+ *
+ * Indentation status is auto-detected and preserved when stringifying back using `stringifyJSON`
+ */
+export function parseJSON<T = unknown>(
+  text: string,
+  options?: JSONParseOptions,
+): T {
+  const obj = JSON.parse(text, options?.reviver);
+  storeFormat(text, obj, options);
+  return obj as T;
+}
+
+/**
+ * Converts a JavaScript value to a [JSON](https://www.json.org/json-en.html) string.
+ *
+ * Indentation status is auto detected and preserved when using value from parseJSON.
+ */
+export function stringifyJSON(
+  value: any,
+  options?: JSONStringifyOptions,
+): string {
+  const format = getFormat(value, options);
+  const str = JSON.stringify(value, options?.replacer, format.indent);
+  return format.whitespace.start + str + format.whitespace.end;
+}
+
+// -- types --
+
+export interface JSONParseOptions extends FormatOptions {
+  /**
+   * A function that transforms the results. This function is called for each member of the object.
+   */
+  reviver?: (this: any, key: string, value: any) => any;
+}
+
+export interface JSONStringifyOptions extends FormatOptions {
+  /**
+   * A function that transforms the results. This function is called for each member of the object.
+   */
+  replacer?: (this: any, key: string, value: any) => any;
+}

--- a/test/bench.mjs
+++ b/test/bench.mjs
@@ -39,7 +39,7 @@ defineBench("yaml", {
 });
 
 defineBench("toml", {
-  'confbox.parseTOML': () => {
+  "confbox.parseTOML": () => {
     confbox.parseTOML(fixtures.toml);
   },
   "BinaryMuse/toml-node": () => {
@@ -54,7 +54,7 @@ defineBench("toml", {
 });
 
 defineBench("json5", {
-  'confbox.parseJSON5': () => {
+  "confbox.parseJSON5": () => {
     confbox.parseJSON5(fixtures.json5);
   },
   "json5/json5": () => {
@@ -63,7 +63,7 @@ defineBench("json5", {
 });
 
 defineBench("jsonc", {
-  'confbox.parseJSONC': () => {
+  "confbox.parseJSONC": () => {
     confbox.parseJSONC(fixtures.jsonc);
   },
   "microsoft/node-jsonc-parser": () => {
@@ -72,7 +72,7 @@ defineBench("jsonc", {
 });
 
 defineBench("json", {
-  'JSON.parse': () => {
+  "JSON.parse": () => {
     JSON.parse(fixtures.json);
   },
   "confbox.parseJSON": () => {

--- a/test/bench.mjs
+++ b/test/bench.mjs
@@ -39,7 +39,7 @@ defineBench("yaml", {
 });
 
 defineBench("toml", {
-  confbox: () => {
+  'confbox.parseTOML': () => {
     confbox.parseTOML(fixtures.toml);
   },
   "BinaryMuse/toml-node": () => {
@@ -54,7 +54,7 @@ defineBench("toml", {
 });
 
 defineBench("json5", {
-  confbox: () => {
+  'confbox.parseJSON5': () => {
     confbox.parseJSON5(fixtures.json5);
   },
   "json5/json5": () => {
@@ -63,11 +63,26 @@ defineBench("json5", {
 });
 
 defineBench("jsonc", {
-  confbox: () => {
+  'confbox.parseJSONC': () => {
     confbox.parseJSONC(fixtures.jsonc);
   },
   "microsoft/node-jsonc-parser": () => {
     jsoncParser.parse(fixtures.jsonc);
+  },
+});
+
+defineBench("json", {
+  'JSON.parse': () => {
+    JSON.parse(fixtures.json);
+  },
+  "confbox.parseJSON": () => {
+    confbox.parseJSON(fixtures.json);
+  },
+  "confbox.parseJSON5": () => {
+    confbox.parseJSON5(fixtures.json);
+  },
+  "confbox.parseJSONC": () => {
+    confbox.parseJSONC(fixtures.json);
   },
 });
 

--- a/test/fixtures.mjs
+++ b/test/fixtures.mjs
@@ -44,4 +44,4 @@ export const json = /* json */ `
   }
 }
 
-`
+`;

--- a/test/fixtures.mjs
+++ b/test/fixtures.mjs
@@ -33,3 +33,15 @@ export const jsonc = /* jsonc */ `
   }
 }
 `.trim();
+
+export const json = /* json */ `
+
+{
+  "title": "Example",
+  "owner": {
+    "name": "Preston-Werner",
+    "dob": "1979-05-27T07:32:00-08:00"
+  }
+}
+
+`

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -52,4 +52,16 @@ describe("confbox", () => {
       ).toMatchObject(expectedObjWithDate);
     });
   });
+
+  describe("json", () => {
+    it("parse fixture", () => {
+      expect(confbox.parseJSON(fixtures.json)).toMatchObject(expectedObj);
+    });
+
+    it("stringify", () => {
+      expect(confbox.stringifyJSON(confbox.parseJSON(fixtures.json))).toBe(
+        fixtures.json,
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR adds json parse/serialize utils with auto format preservation.

The format info is stored in a hidden value and as long as operating on input object, the format will be preserved! (we probably need to document common mistakes later)