### PR TITLE
feat!: migrate to `yaml`

### DIFF
--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,8 +1,8 @@
-import { load, dump } from "js-yaml";
+import { parse, stringify } from "yaml";
 import { type FormatOptions, getFormat, storeFormat } from "./_format";
 
-// Source: https://github.com/nodeca/js-yaml
-// Types:  https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/js-yaml/index.d.ts
+// https://eemeli.org/yaml/#yaml
+// https://github.com/eemeli/yaml
 
 /**
  * Converts a [YAML](https://yaml.org/) string into an object.
@@ -25,7 +25,10 @@ export function parseYAML<T = unknown>(
   text: string,
   options?: YAMLParseOptions,
 ): T {
-  const obj = load(text, options);
+  const obj = parse(text, {
+    customTags: ["timestamp"],
+    ...options,
+  });
   storeFormat(text, obj, options);
   return obj as T;
 }
@@ -46,7 +49,7 @@ export function stringifyYAML(
   const format = getFormat(value, { preserveIndentation: false });
   const indentSize =
     typeof format.indent === "string" ? format.indent.length : format.indent;
-  const str = dump(value, {
+  const str = stringify(value, {
     indent: indentSize,
     ...options,
   });

--- a/test/fixtures.mjs
+++ b/test/fixtures.mjs
@@ -30,7 +30,7 @@ types:
     - 3
   object:
     key: value
-  'null': null
+  "null": null
   date: 1979-05-27T15:32:00.000Z
 `;
 


### PR DESCRIPTION
Migrate from [js-yaml](https://www.npmjs.com/package/js-yaml) to [yaml](https://www.npmjs.com/package/yaml) which is more spec compliant and maintained. (context: #33 and https://github.com/orgs/remarkjs/discussions/1006#discussioncomment-2955255)


Downside is it adds ~60kB more to the bundle and ~10x slower.

<img width="542" alt="image" src="https://github.com/user-attachments/assets/414b66fc-ca46-4a48-a841-8c1eb64c537e" />
