### PR TITLE
feat(json): default indentation to 2 for raw objects

### DIFF
--- a/src/_format.ts
+++ b/src/_format.ts
@@ -85,7 +85,7 @@ export function getFormat(
   whitespace: { start: string; end: string };
 } {
   if (!obj || typeof obj !== "object" || !(ftmSymbol in obj)) {
-    return { indent: opts?.indent, whitespace: { start: "", end: "" } };
+    return { indent: opts?.indent ?? 2, whitespace: { start: "", end: "" } };
   }
   const format = obj[ftmSymbol] as FormatInfo;
   const indent = opts?.indent || detectIndent(format.sample || "").indent;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -68,6 +68,12 @@ describe("confbox", () => {
         fixtures.json,
       );
     });
+
+    it("stringify from raw object", () => {
+      expect(confbox.stringifyJSON(JSON.parse(fixtures.json))).toBe(
+        fixtures.json.trim(),
+      );
+    });
   });
 
   describe("ini", () => {


### PR DESCRIPTION
Defaults the indentation to `2` for objects which didn't originate from confbox's parse function. Otherwise, this will use the provided indent or the detected indent.

