### PR TITLE
fix(yaml): export YAMLException type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { parseJSONC, stringifyJSONC } from "./jsonc";
 export type { JSONCParseError, JSONCParseOptions } from "./jsonc";
 
 export { parseYAML, stringifyYAML } from "./yaml";
-export type { YAMLParseOptions, YAMLStringifyOptions } from "./yaml";
+export type { YAMLParseOptions, YAMLStringifyOptions, YAMLException } from "./yaml";
 
 export { parseJSON, stringifyJSON } from "./json";
 export type { JSONParseOptions, JSONStringifyOptions } from "./json";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ export type { JSON5ParseOptions, JSON5StringifyOptions } from "./json5";
 export { parseJSONC, stringifyJSONC } from "./jsonc";
 export type { JSONCParseError, JSONCParseOptions } from "./jsonc";
 
-export { parseYAML, stringifyYAML } from "./yaml";
-export type { YAMLParseOptions, YAMLStringifyOptions, YAMLException } from "./yaml";
+export { parseYAML, stringifyYAML, YAMLException } from "./yaml";
+export type { YAMLParseOptions, YAMLStringifyOptions } from "./yaml";
 
 export { parseJSON, stringifyJSON } from "./json";
 export type { JSONParseOptions, JSONStringifyOptions } from "./json";

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -48,7 +48,7 @@ export function stringifyYAML(value: any, options?: YAMLStringifyOptions): strin
 
 // --- Types ---
 
-export type { YAMLException };
+export { YAMLException };
 
 export interface YAMLParseOptions extends FormatOptions {
   /** string to be used as a file path in error/warning messages. */

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,4 +1,4 @@
-import { load, dump } from "js-yaml";
+import { load, dump, YAMLException } from "js-yaml";
 import { type FormatOptions, getFormat, storeFormat } from "./_format";
 
 // Source: https://github.com/nodeca/js-yaml
@@ -48,6 +48,8 @@ export function stringifyYAML(value: any, options?: YAMLStringifyOptions): strin
 
 // --- Types ---
 
+export type { YAMLException };
+
 export interface YAMLParseOptions extends FormatOptions {
   /** string to be used as a file path in error/warning messages. */
   filename?: string | undefined;
@@ -95,20 +97,3 @@ export interface YAMLStringifyOptions extends FormatOptions {
   replacer?: ((key: string, value: any) => any) | undefined;
 }
 
-interface Mark {
-  buffer: string;
-  column: number;
-  line: number;
-  name: string;
-  position: number;
-  snippet: string;
-}
-
-declare class YAMLException extends Error {
-  constructor(reason?: string, mark?: Mark);
-  toString(compact?: boolean): string;
-  name: string;
-  reason: string;
-  message: string;
-  mark: Mark;
-}


### PR DESCRIPTION
Closes #17

## Problem

`YAMLException` is the error thrown by `js-yaml` when YAML parsing fails, and it's already referenced in the `YAMLParseOptions.onWarning` callback signature. However, it was declared locally via a private `declare class YAMLException` without an `export` keyword, making it impossible for users to import or catch the type explicitly:

```ts
import { YAMLException } from 'confbox/yaml' // Error: not exported
```

## Fix

- Import `YAMLException` from `js-yaml` (already a dev dependency via `@types/js-yaml`)
- Re-export it as a proper type from `confbox/yaml`
- Re-export it from the main `confbox` entry point as well
- Remove the now-redundant local `declare class YAMLException` and its supporting `interface Mark`

After this change, users can catch YAML parse errors with full type safety:

```ts
import { parseYAML, YAMLException } from 'confbox'
// or
import { parseYAML, YAMLException } from 'confbox/yaml'

try {
  parseYAML(input)
} catch (e) {
  if (e instanceof YAMLException) {
    console.error(e.reason, e.mark)
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YAMLException is now part of the public API, so apps can reference and handle YAML parsing exceptions directly.
* **Behavior Changes**
  * Warning callback now receives detailed exception information when YAML parsing issues occur, enabling richer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->