### PR TITLE
build: expose `confbox/json` subpath

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -7,6 +7,7 @@ export default defineBuildConfig({
       input: [
         "src/index.ts",
         "src/ini.ts",
+        "src/json.ts",
         "src/json5.ts",
         "src/jsonc.ts",
         "src/toml.ts",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "exports": {
     ".": "./dist/index.mjs",
     "./ini": "./dist/ini.mjs",
+    "./json": "./dist/json.mjs",
     "./json5": "./dist/json5.mjs",
     "./jsonc": "./dist/jsonc.mjs",
     "./toml": "./dist/toml.mjs",


### PR DESCRIPTION
resolves #88

### Summary

Adds `./json` to `exports` and `src/json.ts` to the build entries.

Every other parser is already reachable on its own. It looks like it was simply missed when the subpaths were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a publicly accessible JSON module export.
  * Included the JSON module in the package’s bundled output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->