### PR TITLE
perf: use WeakMap for format storage

### DIFF
--- a/src/_format.ts
+++ b/src/_format.ts
@@ -32,6 +32,7 @@ export interface FormatOptions {
 }
 
 const ftmSymbol = Symbol.for("__confbox_fmt__");
+const formatMap = new WeakMap<object, FormatInfo>();
 
 const WhitespaceStartRe = /^(\s+)/;
 const WhitespaceEndRe = /(\s+)$/;
@@ -62,12 +63,7 @@ export function storeFormat(text: string, obj: any, opts?: FormatOptions): void 
     return;
   }
 
-  Object.defineProperty(obj, ftmSymbol, {
-    enumerable: false,
-    configurable: true,
-    writable: true,
-    value: detectFormat(text, opts),
-  });
+  formatMap.set(obj, detectFormat(text, opts));
 }
 
 export function getFormat(
@@ -77,10 +73,15 @@ export function getFormat(
   indent: string | number | undefined;
   whitespace: { start: string; end: string };
 } {
-  if (!obj || typeof obj !== "object" || !(ftmSymbol in obj)) {
+  const format =
+    (obj && typeof obj === "object" ? formatMap.get(obj) : undefined) ||
+    (obj && typeof obj === "object" && ftmSymbol in obj
+      ? (obj[ftmSymbol] as FormatInfo)
+      : undefined);
+
+  if (!format) {
     return { indent: opts?.indent ?? 2, whitespace: { start: "", end: "" } };
   }
-  const format = obj[ftmSymbol] as FormatInfo;
   const indent = opts?.indent || detectIndent(format.sample || "").indent;
   return {
     indent,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -79,4 +79,12 @@ describe("confbox", () => {
       expect(confbox.stringifyINI(confbox.parseINI(fixtures.ini))).toBe(fixtures.ini);
     });
   });
+
+  describe("format storage", () => {
+    it("does not pollute object with symbol properties", () => {
+      const parsed = confbox.parseJSON('{\n  "foo": "bar"\n}');
+      expect(Object.getOwnPropertySymbols(parsed)).toEqual([]);
+      expect(confbox.stringifyJSON(parsed)).toBe('{\n  "foo": "bar"\n}');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`storeFormat` used `Object.defineProperty` to attach formatting metadata directly to parsed objects as a non-enumerable symbol property (`Symbol.for("__confbox_fmt__")`). This modifies the parsed object and can fail on frozen objects.

## Root Cause

Formatting metadata was stored directly on the parsed object reference using symbol properties rather than an isolated lookup table.

## Fix

- Used a module-level `WeakMap` to store format information associated with parsed object references.
- Preserved backwards-compatible fallback for objects carrying legacy symbol formatting metadata in `getFormat`.

## Testing

- Added unit test in `test/index.test.ts` verifying parsed objects contain no own symbol properties while preserving indentation round-trip formatting.
- Verified all unit tests and type checks pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved format metadata handling for parsed JSON objects.
  - Preserved compatibility with existing formatting metadata.
  - Ensured objects remain free of internal symbol properties and serialize to the expected JSON text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->