### PR TITLE
feat(yaml)!: bump js-yaml to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@types/ini": "^4.1.1",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^26",
     "@vitest/coverage-v8": "^4.1.11",
     "automd": "^0.4.3",
@@ -50,7 +49,7 @@
     "ini": "^7.0.0",
     "jiti": "^2.7.0",
     "js-toml": "^2.0.1",
-    "js-yaml": "^4.3.2",
+    "js-yaml": "^5.4.1",
     "json5": "^2.2.3",
     "jsonc-parser": "^3.3.1",
     "mitata": "^1.0.34",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@types/ini':
         specifier: ^4.1.1
         version: 4.1.1
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^26
         version: 26.4.1
@@ -39,8 +36,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       js-yaml:
-        specifier: ^4.3.2
-        version: 4.3.2
+        specifier: ^5.4.1
+        version: 5.4.1
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -875,9 +872,6 @@ packages:
   '@types/ini@4.1.1':
     resolution: {integrity: sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==}
 
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
-
   '@types/node@26.4.1':
     resolution: {integrity: sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==}
 
@@ -1408,8 +1402,8 @@ packages:
   js-toml@2.0.1:
     resolution: {integrity: sha512-HH5e3fCXraX+FDTjpu0IuITue9AjKxAATaIoRDcUqqUyZnBdPCYlxHPpjGEwZW93WT6r8lPY73O0ADugrtQR1g==}
 
-  js-yaml@4.3.2:
-    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
+  js-yaml@5.4.1:
+    resolution: {integrity: sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==}
     hasBin: true
 
   json5@2.2.3:
@@ -2188,8 +2182,6 @@ snapshots:
 
   '@types/ini@4.1.1': {}
 
-  '@types/js-yaml@4.0.9': {}
-
   '@types/node@26.4.1':
     dependencies:
       undici-types: 8.3.0
@@ -2628,7 +2620,7 @@ snapshots:
       chevrotain: 12.0.0
       xregexp: 5.1.2
 
-  js-yaml@4.3.2:
+  js-yaml@5.4.1:
     dependencies:
       argparse: 2.0.1
 

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -2,19 +2,20 @@ import { load, dump } from "js-yaml";
 import { type FormatOptions, getFormat, storeFormat } from "./_format";
 
 // Source: https://github.com/nodeca/js-yaml
-// Types:  https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/js-yaml/index.d.ts
+// Types:  https://github.com/nodeca/js-yaml/blob/master/dist/js-yaml.d.ts
 
 /**
  * Converts a [YAML](https://yaml.org/) string into an object.
  *
- * @NOTE This function does **not** understand multi-document sources, it throws exception on those.
+ * @NOTE This function does **not** understand multi-document or empty sources, it throws exception on those.
  *
  * @NOTE Comments are not preserved after parsing.
  *
- * @NOTE This function does **not** support schema-specific tag resolution restrictions.
- * So, the JSON schema is not as strictly defined in the YAML specification.
- * It allows numbers in any notation, use `Null` and `NULL` as `null`, etc.
- * The core schema also has no such restrictions. It allows binary notation for integers.
+ * @NOTE Parsing uses the YAML 1.2 core schema. Tags outside of it (`!!timestamp`, `!!merge`,
+ * `!!binary`, `!!omap`, `!!pairs` and `!!set`) are not resolved, so timestamps are returned as
+ * strings and `<<` merge keys are kept as-is. Opt back in by installing `js-yaml` alongside
+ * confbox and passing a schema:
+ * `parseYAML(text, { schema: CORE_SCHEMA.withTags(mergeTag, timestampTag) })`.
  *
  * @template T The type of the return value.
  * @param text The YAML string to parse.
@@ -49,66 +50,72 @@ export function stringifyYAML(value: any, options?: YAMLStringifyOptions): strin
 // --- Types ---
 
 export interface YAMLParseOptions extends FormatOptions {
-  /** string to be used as a file path in error/warning messages. */
-  filename?: string | undefined;
-  /** function to call on warning messages. */
-  onWarning?(this: null, e: YAMLException): void;
-  /** specifies a schema to use. */
-  schema?: any | undefined;
-  /** compatibility with JSON.parse behaviour. */
-  json?: boolean | undefined;
-  /** listener for parse events */
-  listener?(this: any, eventType: any, state: any): void;
+  /** File path used in error messages. */
+  filename?: string;
+  /** Maximum nesting depth for collections. Aliases are not taken into account. (default: 100) */
+  maxDepth?: number;
+  /** Schema to use. (default: `CORE_SCHEMA`) */
+  schema?: any;
+  /** Enables compatibility with `JSON.parse` behavior. Duplicate keys in a mapping override values instead of throwing an error. (default: false) */
+  json?: boolean;
+  /**
+   * Maximum total number of keys processed by merge (`<<`) across one load call.
+   * Each member of a merge sequence also counts as one key. Set to `-1` to disable the limit. (default: 10000)
+   */
+  maxTotalMergeKeys?: number;
+  /** Maximum number of alias nodes (`*ref`) per document. Set to `0` to reject all aliases, or to `-1` for no limit. (default: -1) */
+  maxAliases?: number;
 }
 
 export interface YAMLStringifyOptions extends FormatOptions {
-  /** indentation width to use (in spaces). */
-  indent?: number | undefined;
-  /** when true, will not add an indentation level to array elements */
-  noArrayIndent?: boolean | undefined;
-  /** do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types. */
-  skipInvalid?: boolean | undefined;
-  /** specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere */
-  flowLevel?: number | undefined;
-  /** Each tag may have own set of styles.    - "tag" => "style" map. */
-  styles?: { [x: string]: any } | undefined;
-  /** specifies a schema to use. */
-  schema?: any | undefined;
-  /** if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false) */
-  sortKeys?: boolean | ((a: any, b: any) => number) | undefined;
-  /** set max line width. (default: 80) */
-  lineWidth?: number | undefined;
-  /** if true, don't convert duplicate objects into references (default: false) */
-  noRefs?: boolean | undefined;
-  /** if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false) */
-  noCompatMode?: boolean | undefined;
+  /** Indentation width in spaces. (default: 2) */
+  indent?: number;
+  /** Does not add an indentation level to array elements when enabled. (default: false) */
+  seqNoIndent?: boolean;
+  /** Allows a nested collection to start on the same line after `-`. (default: true) */
+  seqInlineFirst?: boolean;
+  /** Preferred line width for folding. Unbreakable and more-indented lines may exceed it. Set to `-1` for unlimited width. (default: 80) */
+  lineWidth?: number;
+  /** Adds spaces inside flow collection brackets: `{a: 1}` becomes `{ a: 1 }`. (default: false) */
+  flowBracketPadding?: boolean;
+  /** Omits the space after commas in flow collections: `[1, 2]` becomes `[1,2]`. (default: false) */
+  flowSkipCommaSpace?: boolean;
   /**
-   * if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
-   * Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false).
+   * Omits the space after `:` in flow mappings: `{"a": 1}` becomes `{"a":1}`.
+   *
+   * This forces `quoteFlowKeys`; otherwise `a:1` would be parsed as a single plain scalar instead of a mapping entry. (default: false)
    */
-  condenseFlow?: boolean | undefined;
-  /** strings will be quoted using this quoting style. If you specify single quotes, double quotes will still be used for non-printable characters. (default: `'`) */
-  quotingType?: "'" | '"' | undefined;
-  /** if true, all non-key strings will be quoted even if they normally don't need to. (default: false) */
-  forceQuotes?: boolean | undefined;
-  /** callback `function (key, value)` called recursively on each key/value in source object (see `replacer` docs for `JSON.stringify`). */
-  replacer?: ((key: string, value: any) => any) | undefined;
-}
-
-interface Mark {
-  buffer: string;
-  column: number;
-  line: number;
-  name: string;
-  position: number;
-  snippet: string;
-}
-
-declare class YAMLException extends Error {
-  constructor(reason?: string, mark?: Mark);
-  toString(compact?: boolean): string;
-  name: string;
-  reason: string;
-  message: string;
-  mark: Mark;
+  flowSkipColonSpace?: boolean;
+  /** Quotes flow mapping keys: `{a: 1}` becomes `{"a": 1}`. (default: false) */
+  quoteFlowKeys?: boolean;
+  /** Quoting style to use when a string needs quotes. (default: `single`) */
+  quoteStyle?: "single" | "double";
+  /** Quotes all non-key strings using `quoteStyle`. (default: false) */
+  forceQuotes?: boolean;
+  /**
+   * Customizes how strings are rendered as plain, quoted, literal, or folded scalars.
+   * Rules are applied in array order; providing this option replaces the default rules.
+   */
+  scalarStyleRules?: readonly ((layout: any) => void)[];
+  /** Prints an explicit tag before an anchor: `&ref_0 !!set` becomes `!!set &ref_0`. (default: false) */
+  tagBeforeAnchor?: boolean;
+  /** Schema to use. (default: `DUMP_SCHEMA`) */
+  schema?: any;
+  /**
+   * Skips invalid types instead of throwing. Invalid mapping pairs and sequence items are skipped;
+   * `undefined` sequence items are serialized as `null`. (default: false)
+   */
+  skipInvalid?: boolean;
+  /** Inlines duplicate objects instead of converting them into references. (default: false) */
+  noRefs?: boolean;
+  /** Nesting level at which collections switch from block to flow style. Set to `-1` to never switch automatically. (default: -1) */
+  flowLevel?: number;
+  /**
+   * Sorts mapping keys when `true`. A function can be provided to define the sort order. (default: false)
+   *
+   * @deprecated Use `transform` to reorder mapping items.
+   */
+  sortKeys?: boolean | ((a: any, b: any) => number);
+  /** Mutates the generated AST before it is rendered. */
+  transform?: (documents: any[]) => void;
 }

--- a/test/bench.mjs
+++ b/test/bench.mjs
@@ -3,7 +3,7 @@ import { bench, run, summary } from "mitata";
 import nodeToml from "toml";
 import * as jsToml from "js-toml";
 import * as smolToml from "smol-toml";
-import jsYaml from "js-yaml";
+import * as jsYaml from "js-yaml";
 import yaml from "yaml";
 import * as json5 from "json5";
 import * as jsoncParser from "jsonc-parser";

--- a/test/fixtures.mjs
+++ b/test/fixtures.mjs
@@ -31,7 +31,7 @@ types:
   object:
     key: value
   'null': null
-  date: 1979-05-27T15:32:00.000Z
+  date: '1979-05-27T07:32:00-08:00'
 `;
 
 export const toml = /* toml */ `

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,7 +46,7 @@ describe("confbox", () => {
 
   describe("yaml", () => {
     it("parse", () => {
-      expect(confbox.parseYAML(fixtures.yaml)).toMatchObject(fixtures.objWithDate);
+      expect(confbox.parseYAML(fixtures.yaml)).toMatchObject(fixtures.obj);
     });
 
     it("stringify", () => {


### PR DESCRIPTION
Bumps `js-yaml` from 4.3.2 to 5.4.1.

## Options

v5 ships its own typings, so `@types/js-yaml` is dropped. Both option interfaces are re-copied from `js-yaml/dist/js-yaml.d.ts` per the hand-copy convention.

**Parse** — `onWarning` and `listener` removed; `maxDepth`, `maxAliases`, `maxTotalMergeKeys` added.

**Stringify** — `noArrayIndent` → `seqNoIndent`, `quotingType` → `quoteStyle` (`"single" | "double"`), `condenseFlow` → `flowSkipCommaSpace` / `flowSkipColonSpace`. Removed: `styles`, `noCompatMode`, `replacer`. Added: `transform`, `scalarStyleRules`, `flowBracketPadding`, `quoteFlowKeys`, `tagBeforeAnchor`, `seqInlineFirst`.

## Breaking

`parseYAML` now uses the **YAML 1.2 core schema**, which is js-yaml v5's default and also what `eemeli/yaml` has defaulted to since v2:

- timestamps parse as strings, not `Date`
- `<<:` merge keys are kept as a literal `"<<"` key
- explicit `!!binary`, `!!set` and `!!omap` now **throw** (`unknown scalar tag !<tag:yaml.org,2002:binary>`) rather than degrading

Any subset can be restored per-call. This needs `js-yaml` installed alongside confbox, since confbox bundles it rather than exposing it — the schema is duck-typed, so an instance from a separate copy works:

```js
import { CORE_SCHEMA, mergeTag, timestampTag } from "js-yaml";

parseYAML(text, { schema: CORE_SCHEMA.withTags(mergeTag, timestampTag) });
```

Separately, and not a consequence of the schema change: `parseYAML("")` now throws `expected a document, but the input is empty` where v4 returned `undefined`.

Both are noted in the `parseYAML` JSDoc. Given the breakage this wants a 0.3.0.

## Other

- The YAML fixture's date is now `'1979-05-27T07:32:00-08:00'`, matching the JSON/JSONC/JSON5 fixtures, so the yaml test asserts against `fixtures.obj`. TOML keeps `objWithDate` — smol-toml does produce a `Date`.
- `test/bench.mjs` needed `import * as jsYaml` — v5 has no default export, so the old default import was silently `undefined`.
- `dependencies` stays empty: v5's `argparse` dep is bin-only and does not reach the bundle (`dist/yaml.mjs` has no external imports).

Lint, `tsc`, tests, build and bench all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - YAML date parsing now preserves timezone-offset values consistently with other supported formats.
  - YAML parsing behavior and test coverage have been aligned with the latest parser version.

- **API Updates**
  - Added controls for parse limits, flow formatting, quoting, scalar styles, anchors, and transformation.
  - Renamed array indentation and quoting options.
  - Removed several legacy parsing and serialization options, along with obsolete error and location declarations.
  - Empty YAML sources now throw an error; YAML 1.2 core schema behavior is documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->