### PR TITLE
fix: strip leading UTF-8 BOM before parsing

### DIFF
--- a/src/_format.ts
+++ b/src/_format.ts
@@ -33,15 +33,26 @@ export interface FormatOptions {
 
 const ftmSymbol = Symbol.for("__confbox_fmt__");
 
+// Note: `\s` matches `U+FEFF`, so a leading BOM is captured (and later restored) as whitespace.
 const WhitespaceStartRe = /^(\s+)/;
 const WhitespaceEndRe = /(\s+)$/;
+
+/**
+ * Removes a leading UTF-8 BOM (`U+FEFF`) so that upstream parsers never see it.
+ *
+ * The BOM is still captured as leading whitespace by {@link detectFormat}, so it is restored
+ * when stringifying back (unless `preserveWhitespace` is `false`).
+ */
+export function stripBOM(text: string): string {
+  return text.charCodeAt(0) === 0xfe_ff ? text.slice(1) : text;
+}
 
 export function detectFormat(text: string, opts: FormatOptions = {}): FormatInfo {
   // Keep ref to a sample of the original text only if need to later detect indent to reduce memory usage.
   const sample =
     opts.indent === undefined &&
     opts.preserveIndentation !== false &&
-    text.slice(0, opts?.sampleSize || 1024);
+    stripBOM(text).slice(0, opts?.sampleSize || 1024);
 
   const whiteSpace =
     opts.preserveWhitespace === false

--- a/src/ini.ts
+++ b/src/ini.ts
@@ -1,4 +1,5 @@
 import { parse, stringify } from "ini";
+import { stripBOM } from "./_format";
 
 /**
  * Converts an [INI](https://www.ini.org/ini-en.html) string into an object.
@@ -6,7 +7,7 @@ import { parse, stringify } from "ini";
  * **Note:** Style and indentation are not preserved currently.
  */
 export function parseINI<T = unknown>(text: string, options?: INIParseOptions): T {
-  const obj = parse(text, options);
+  const obj = parse(stripBOM(text), options);
   return obj as T;
 }
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,4 +1,4 @@
-import { getFormat, storeFormat, type FormatOptions } from "./_format";
+import { getFormat, storeFormat, stripBOM, type FormatOptions } from "./_format";
 
 /**
  * Converts a [JSON](https://www.json.org/json-en.html) string into an object.
@@ -6,7 +6,7 @@ import { getFormat, storeFormat, type FormatOptions } from "./_format";
  * Indentation status is auto-detected and preserved when stringifying back using `stringifyJSON`
  */
 export function parseJSON<T = unknown>(text: string, options?: JSONParseOptions): T {
-  const obj = JSON.parse(text, options?.reviver);
+  const obj = JSON.parse(stripBOM(text), options?.reviver);
   storeFormat(text, obj, options);
   return obj as T;
 }

--- a/src/json5.ts
+++ b/src/json5.ts
@@ -1,4 +1,4 @@
-import { getFormat, storeFormat, type FormatOptions } from "./_format";
+import { getFormat, storeFormat, stripBOM, type FormatOptions } from "./_format";
 import parse from "json5/lib/parse.js";
 import stringify from "json5/lib/stringify";
 
@@ -13,7 +13,7 @@ import stringify from "json5/lib/stringify";
  * @returns The JavaScript value converted from the JSON5 string.
  */
 export function parseJSON5<T = unknown>(text: string, options?: JSON5ParseOptions): T {
-  const obj = parse(text, options?.reviver);
+  const obj = parse(stripBOM(text), options?.reviver);
   storeFormat(text, obj, options);
   return obj as T;
 }

--- a/src/jsonc.ts
+++ b/src/jsonc.ts
@@ -1,4 +1,4 @@
-import { storeFormat, type FormatOptions } from "./_format";
+import { storeFormat, stripBOM, type FormatOptions } from "./_format";
 import stripJSONComments from "strip-json-comments";
 import { stringifyJSON } from "./json";
 
@@ -19,7 +19,7 @@ import { stringifyJSON } from "./json";
  */
 export function parseJSONC<T = unknown>(text: string, options?: JSONCParseOptions): T {
   const obj = JSON.parse(
-    stripJSONComments(text, {
+    stripJSONComments(stripBOM(text), {
       trailingCommas: options?.allowTrailingComma,
     }),
   );

--- a/src/toml.ts
+++ b/src/toml.ts
@@ -1,4 +1,4 @@
-import { getFormat, storeFormat } from "./_format";
+import { getFormat, storeFormat, stripBOM } from "./_format";
 import { parse, stringify } from "smol-toml";
 
 // Source: https://github.com/squirrelchat/smol-toml
@@ -13,7 +13,7 @@ import { parse, stringify } from "smol-toml";
  * @returns The JavaScript value converted from the TOML string.
  */
 export function parseTOML<T = unknown>(text: string): T {
-  const obj = parse(text);
+  const obj = parse(stripBOM(text));
   storeFormat(text, obj, { preserveIndentation: false });
   return obj as T;
 }

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,5 +1,5 @@
 import { load, dump, YAMLException } from "js-yaml";
-import { type FormatOptions, getFormat, storeFormat } from "./_format";
+import { type FormatOptions, getFormat, storeFormat, stripBOM } from "./_format";
 
 // Source: https://github.com/nodeca/js-yaml
 // Types:  https://github.com/nodeca/js-yaml/blob/master/dist/js-yaml.d.ts
@@ -23,7 +23,7 @@ import { type FormatOptions, getFormat, storeFormat } from "./_format";
  * @returns The JavaScript value converted from the YAML string.
  */
 export function parseYAML<T = unknown>(text: string, options?: YAMLParseOptions): T {
-  const obj = load(text, options);
+  const obj = load(stripBOM(text), options);
   storeFormat(text, obj, options);
   return obj as T;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -75,6 +75,43 @@ describe("confbox", () => {
     });
   });
 
+  describe("bom", () => {
+    const BOM = "\uFEFF";
+
+    const roundTrip = {
+      json: [confbox.parseJSON, confbox.stringifyJSON],
+      jsonc: [confbox.parseJSONC, confbox.stringifyJSONC],
+      json5: [confbox.parseJSON5, confbox.stringifyJSON5],
+      yaml: [confbox.parseYAML, confbox.stringifyYAML],
+      toml: [confbox.parseTOML, confbox.stringifyTOML],
+    } as const;
+
+    for (const [format, [parse, stringify]] of Object.entries(roundTrip)) {
+      const fixture = (fixtures as Record<string, string>)[format].trim();
+
+      it(`${format} parses with a leading BOM`, () => {
+        expect(parse(BOM + fixture)).toMatchObject(parse(fixture) as object);
+      });
+
+      it(`${format} preserves the BOM when stringifying back`, () => {
+        expect(stringify(parse(BOM + fixture))).toBe(BOM + stringify(parse(fixture)));
+      });
+
+      // `parseTOML` takes no options, so it always preserves whitespace.
+      if (format !== "toml") {
+        it(`${format} drops the BOM with preserveWhitespace: false`, () => {
+          expect(stringify(parse(BOM + fixture, { preserveWhitespace: false }))).not.toContain(BOM);
+        });
+      }
+    }
+
+    it("ini parses with a leading BOM", () => {
+      expect(confbox.parseINI(BOM + fixtures.ini)).toMatchObject(
+        confbox.parseINI(fixtures.ini) as object,
+      );
+    });
+  });
+
   describe("ini", () => {
     it.skip("parse", () => {
       expect(confbox.parseINI(fixtures.ini)).toMatchObject(fixtures.obj);


### PR DESCRIPTION
## Problem

BOM handling was inconsistent across formats — whatever the upstream lib happened to do:

| Format | `parse` with a leading `U+FEFF` |
| --- | --- |
| JSON | **throws** — `Unexpected token '﻿'` |
| JSONC | **throws** — same (`strip-json-comments` hands it to `JSON.parse`) |
| TOML | **throws** — `only letter, numbers, dashes and underscores are allowed in keys` |
| JSON5 | ok (BOM is whitespace per the JSON5 spec) |
| YAML | ok (`js-yaml` handles it) |
| INI | ok — BOM swallowed, since `ini` trims lines and `String.trim()` strips `U+FEFF` |

BOM-prefixed config files are common on Windows, so the three throwing formats are a real gap.

## Change

A shared `stripBOM()` helper in `src/_format.ts`, applied in all six parsers:

```ts
export function stripBOM(text: string): string {
  return text.charCodeAt(0) === 0xfe_ff ? text.slice(1) : text;
}
```

Each parser feeds the stripped text to its upstream lib but still passes the **original** text to `storeFormat()`, so the BOM lands in `whiteSpace.start` and is re-emitted by `stringify` — round-trip stays exact. `detectFormat` now samples from the stripped text so a BOM can't skew indent detection, and there's a comment noting that `\s` matching `U+FEFF` is what makes the preservation work (previously load-bearing but undocumented).

INI is unchanged in behavior — it preserves no style at all, so the BOM is still dropped on stringify.

## Tests

A `describe("bom")` block loops the five style-preserving formats over the existing fixtures: parses with a BOM, round-trips it, and drops it under `preserveWhitespace: false`, plus an INI parse case. `parseTOML` takes no options parameter, so it's excluded from the `preserveWhitespace: false` assertion.

`pnpm test` and `pnpm build` pass.

## Not addressed

A BOM anywhere but position 0 is still absorbed into data — `parseYAML("a: 1\n﻿b: 2")` yields a key of `"﻿b"`. That input is malformed, and stripping mid-document would corrupt string values that legitimately contain `U+FEFF`.

🤖 Generated with AI assistant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of JSON, JSONC, JSON5, YAML, TOML, and INI files containing a leading UTF-8 byte-order mark (BOM).
  * Improved format detection for text files with a BOM.

* **Enhancements**
  * Preserved BOM characters during round-trip formatting where applicable.
  * Supported removing the BOM when whitespace preservation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->